### PR TITLE
changed i2p browser opening to be more debian friendly

### DIFF
--- a/kali-anonsurf-deb-src/etc/init.d/anonsurf
+++ b/kali-anonsurf-deb-src/etc/init.d/anonsurf
@@ -52,7 +52,6 @@ TOR_UID="debian-tor"
 # Tor's TransPort
 TOR_PORT="9040"
 
-
 function notify {
 	if [ -e /usr/bin/notify-send ]; then
 		/usr/bin/notify-send "AnonSurf" "$1"
@@ -81,7 +80,7 @@ function starti2p {
 	echo -e 'nameserver 127.0.0.1\nnameserver 209.222.18.222\nnameserver 209.222.18.218' > /etc/resolv.conf
 	echo -e " $GREEN*$BLUE Modified resolv.conf to use localhost and Private Internet Access DNS"
 	sudo -u i2psvc i2prouter start
-	iceweasel http://127.0.0.1:7657/home &
+	xdg-open http://127.0.0.1:7657/home &
 	notify "I2P daemon started"
 }
 


### PR DESCRIPTION
Changes ```iceweasel``` command in ```starti2p``` to ```xdg-open``` to be more Debian friendly. See #8 for more info.
