### PR TITLE
Moving from sysctl.conf to sysctl.d/kali-anonsurf.conf

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -61,6 +61,7 @@ jobs:
 
     - name: Call Webhook
       run: |
+        VERSION="${{ env.VERSION }}"
         curl -X POST \
         -H 'Content-Type: application/json' \
         -d '{

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -26,16 +26,15 @@ jobs:
 
     - name: Test AnonSurf IPv6 Handling
       run: |
-        chmod +x anonsurf.sh
-        ./anonsurf.sh start
+        anonsurf start
 
         echo "Testing if IPv6 is disabled..."
         if [ "$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')" != "1" ]; then
           echo "ERROR: IPv6 is not disabled!"
-          ./anonsurf.sh stop
+          anonsurf stop
           exit 1
         fi
         echo "IPv6 is successfully disabled."
 
         echo "Stopping AnonSurf and restoring network configuration..."
-        ./anonsurf.sh stop
+        anonsurf stop

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -1,4 +1,4 @@
-name: Test AnonSurf Installation and Functionality
+name: Test AnonSurf Behavior on kali-rolling
 
 on:
   pull_request: # Trigger on all pull requests
@@ -21,47 +21,21 @@ jobs:
     - name: Update packages and install dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
-        
-        # Temporarily move /etc/resolv.conf to avoid conflicts
-        mv /etc/resolv.conf /etc/resolv.conf.backup || true
-
-        # Install required packages
         apt-get update
-        apt-get install -y ca-certificates curl bleachbit resolvconf tor iptables
+        apt-get install -y ca-certificates curl bleachbit tor iptables
 
-        # Restore /etc/resolv.conf after the installation
-        mv /etc/resolv.conf.backup /etc/resolv.conf || true
-
-    - name: Run installer script
+    - name: Test AnonSurf IPv6 Handling
       run: |
-        chmod +x installer.sh
-        ./installer.sh
+        chmod +x anonsurf.sh
+        ./anonsurf.sh start
 
-    - name: Test AnonSurf Functionality
-      run: |
-        echo "Testing 'anonsurf start'..."
-        anonsurf start
-        echo "Testing IPv6 is disabled..."
-        IPv6_STATUS=$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')
-        if [ "$IPv6_STATUS" != "1" ]; then
-          echo "IPv6 was not disabled correctly."
+        echo "Testing if IPv6 is disabled..."
+        if [ "$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')" != "1" ]; then
+          echo "ERROR: IPv6 is not disabled!"
+          ./anonsurf.sh stop
           exit 1
         fi
-        echo "IPv6 was disabled successfully."
-        
-        echo "Testing sysctl configuration..."
-        if ! grep -q "net.ipv6.conf.all.disable_ipv6 = 1" /etc/sysctl.d/kali-anonsurf.conf; then
-          echo "Sysctl configuration for IPv6 is missing."
-          exit 1
-        fi
-        echo "Sysctl configuration is correct."
+        echo "IPv6 is successfully disabled."
 
-        echo "Testing stopping AnonSurf..."
-        anonsurf stop
-
-    - name: Cleanup
-      run: |
-        iptables -F
-        iptables -t nat -F
-        ip6tables -F
-        ip6tables -t nat -F
+        echo "Stopping AnonSurf and restoring network configuration..."
+        ./anonsurf.sh stop

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
-        apt-get install -y dpkg-dev curl bleachbit tor iptables
+        apt-get install -y dpkg-dev curl bleachbit tor iptables secure-delete
 
     - name: Build .deb Package
       run: |

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -24,13 +24,13 @@ jobs:
         apt-get update
         apt-get install -y dpkg-dev curl bleachbit tor iptables secure-delete
 
-    - name: Build .deb Package
+   - name: Run Installer Script
       run: |
-        dpkg-deb --build kali-anonsurf-deb-src/ kali-anonsurf.deb
+        chmod +x installer.sh
+        ./installer.sh
 
-    - name: Install .deb Package
+    - name: Verify Installation
       run: |
-        dpkg -i kali-anonsurf.deb || apt-get -f install -y && dpkg -i kali-anonsurf.deb
         which anonsurf || { echo "ERROR: anonsurf is not installed."; exit 1; }
 
     - name: Test AnonSurf Functionality

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -33,18 +33,4 @@ jobs:
       run: |
         which anonsurf || { echo "ERROR: anonsurf is not installed."; exit 1; }
 
-    - name: Test AnonSurf Functionality
-      run: |
-        echo "Starting AnonSurf..."
-        anonsurf start
-
-        echo "Testing if IPv6 is disabled..."
-        if [ "$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')" != "1" ]; then
-          echo "ERROR: IPv6 is not disabled!"
-          anonsurf stop
-          exit 1
-        fi
-        echo "IPv6 is successfully disabled."
-
-        echo "Stopping AnonSurf and restoring network configuration..."
-        anonsurf stop
+# We can't test anonsurf in a runner due to the way the runner is configured, but at least this tests the build and install in kali-rolling

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -21,13 +21,13 @@ jobs:
     - name: Install dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates curl bleachbit tor iptables
+        apt-get update
+        apt-get install -y ca-certificates curl bleachbit tor iptables
 
     - name: Run Installer Script
       run: |
         chmod +x installer.sh
-        sudo ./installer.sh
+        ./installer.sh
 
     - name: Verify Installation
       run: |
@@ -36,15 +36,15 @@ jobs:
     - name: Test AnonSurf Functionality
       run: |
         echo "Starting AnonSurf..."
-        sudo anonsurf start
+        anonsurf start
 
         echo "Testing if IPv6 is disabled..."
-        if [ "$(sudo sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')" != "1" ]; then
+        if [ "$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')" != "1" ]; then
           echo "ERROR: IPv6 is not disabled!"
-          sudo anonsurf stop
+          anonsurf stop
           exit 1
         fi
         echo "IPv6 is successfully disabled."
 
         echo "Stopping AnonSurf and restoring network configuration..."
-        sudo anonsurf stop
+        anonsurf stop

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -20,8 +20,17 @@ jobs:
 
     - name: Update packages and install dependencies
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        
+        # Temporarily move /etc/resolv.conf to avoid conflicts
+        mv /etc/resolv.conf /etc/resolv.conf.backup || true
+
+        # Install required packages
         apt-get update
         apt-get install -y ca-certificates curl bleachbit resolvconf tor iptables
+
+        # Restore /etc/resolv.conf after the installation
+        mv /etc/resolv.conf.backup /etc/resolv.conf || true
 
     - name: Run installer script
       run: |

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -1,4 +1,4 @@
-name: Test AnonSurf Behavior on kali-rolling
+name: Test AnonSurf Installation and Functionality on kali-rolling
 
 on:
   pull_request: # Trigger on all pull requests
@@ -18,14 +18,24 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Update packages and install dependencies
+    - name: Install dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
-        apt-get install -y ca-certificates curl bleachbit tor iptables
+        apt-get install -y dpkg-dev curl bleachbit tor iptables
 
-    - name: Test AnonSurf IPv6 Handling
+    - name: Build .deb Package
       run: |
+        dpkg-deb --build kali-anonsurf-deb-src/ kali-anonsurf.deb
+
+    - name: Install .deb Package
+      run: |
+        dpkg -i kali-anonsurf.deb || apt-get -f install -y && dpkg -i kali-anonsurf.deb
+        which anonsurf || { echo "ERROR: anonsurf is not installed."; exit 1; }
+
+    - name: Test AnonSurf Functionality
+      run: |
+        echo "Starting AnonSurf..."
         anonsurf start
 
         echo "Testing if IPv6 is disabled..."

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -1,0 +1,58 @@
+name: Test AnonSurf Installation and Functionality
+
+on:
+  pull_request: # Trigger on all pull requests
+    branches:
+      - '**' # All branches for pull requests
+  push: # Trigger on pushes to specific branches
+    branches:
+      - master # Only on merges to master
+
+jobs:
+  test-script:
+    runs-on: ubuntu-latest
+    container:
+      image: kalilinux/kali-rolling:latest  # Use a Kali Linux environment
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Update packages and install dependencies
+      run: |
+        apt-get update
+        apt-get install -y ca-certificates curl bleachbit resolvconf tor iptables
+
+    - name: Run installer script
+      run: |
+        chmod +x installer.sh
+        ./installer.sh
+
+    - name: Test AnonSurf Functionality
+      run: |
+        echo "Testing 'anonsurf start'..."
+        anonsurf start
+        echo "Testing IPv6 is disabled..."
+        IPv6_STATUS=$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')
+        if [ "$IPv6_STATUS" != "1" ]; then
+          echo "IPv6 was not disabled correctly."
+          exit 1
+        fi
+        echo "IPv6 was disabled successfully."
+        
+        echo "Testing sysctl configuration..."
+        if ! grep -q "net.ipv6.conf.all.disable_ipv6 = 1" /etc/sysctl.d/kali-anonsurf.conf; then
+          echo "Sysctl configuration for IPv6 is missing."
+          exit 1
+        fi
+        echo "Sysctl configuration is correct."
+
+        echo "Testing stopping AnonSurf..."
+        anonsurf stop
+
+    - name: Cleanup
+      run: |
+        iptables -F
+        iptables -t nat -F
+        ip6tables -F
+        ip6tables -t nat -F

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -1,4 +1,4 @@
-name: Test AnonSurf Installation and Functionality on kali-rolling
+name: Test AnonSurf Installation on kali-rolling
 
 on:
   pull_request: # Trigger on all pull requests

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -24,7 +24,7 @@ jobs:
         apt-get update
         apt-get install -y dpkg-dev curl bleachbit tor iptables secure-delete
 
-   - name: Run Installer Script
+    - name: Run Installer Script
       run: |
         chmod +x installer.sh
         ./installer.sh

--- a/.github/workflows/test_application.yml
+++ b/.github/workflows/test_application.yml
@@ -21,13 +21,13 @@ jobs:
     - name: Install dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
-        apt-get update
-        apt-get install -y dpkg-dev curl bleachbit tor iptables secure-delete
+        sudo apt-get update
+        sudo apt-get install -y ca-certificates curl bleachbit tor iptables
 
     - name: Run Installer Script
       run: |
         chmod +x installer.sh
-        ./installer.sh
+        sudo ./installer.sh
 
     - name: Verify Installation
       run: |
@@ -36,15 +36,15 @@ jobs:
     - name: Test AnonSurf Functionality
       run: |
         echo "Starting AnonSurf..."
-        anonsurf start
+        sudo anonsurf start
 
         echo "Testing if IPv6 is disabled..."
-        if [ "$(sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')" != "1" ]; then
+        if [ "$(sudo sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}')" != "1" ]; then
           echo "ERROR: IPv6 is not disabled!"
-          anonsurf stop
+          sudo anonsurf stop
           exit 1
         fi
         echo "IPv6 is successfully disabled."
 
         echo "Stopping AnonSurf and restoring network configuration..."
-        anonsurf stop
+        sudo anonsurf stop

--- a/kali-anonsurf-deb-src/DEBIAN/control
+++ b/kali-anonsurf-deb-src/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: kali-anonsurf
-Version: 1.2.4.0
+Version: 1.2.5.0
 Architecture: all
 Maintainer: Und3rf10w
 Installed-Size: 64

--- a/kali-anonsurf-deb-src/DEBIAN/control
+++ b/kali-anonsurf-deb-src/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: kali-anonsurf
-Version: 1.2.5.0
+Version: 1.2.6.0
 Architecture: all
 Maintainer: Und3rf10w
 Installed-Size: 64

--- a/kali-anonsurf-deb-src/etc/init.d/anonsurf
+++ b/kali-anonsurf-deb-src/etc/init.d/anonsurf
@@ -142,8 +142,6 @@ function start {
 	echo "net.ipv6.conf.default.disable_ipv6=1 #kali-anonsurf" >> /etc/sysctl.d/kali-anonsurf.conf
 	sysctl -p /etc/sysctl.d/kali-anonsurf.conf > /dev/null  # have sysctl reread /etc/sysctl.d/kali-anonsurf.conf
 
-
-
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Starting anonymous mode:$RESETCOLOR\n"
 	
 	if [ ! -e /var/run/tor/tor.pid ]; then

--- a/kali-anonsurf-deb-src/etc/init.d/anonsurf
+++ b/kali-anonsurf-deb-src/etc/init.d/anonsurf
@@ -136,11 +136,13 @@ function start {
 	
 	# Kill IPv6 services
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Stopping IPv6 services:$RESETCOLOR\n"
-	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.conf #delete lines containing #kali-anonsurf in /etc/sysctl.conf
-	# add lines to sysctl.conf that will kill ipv6 services
-	echo "net.ipv6.conf.all.disable_ipv6 = 1 #kali-anonsurf" >> /etc/sysctl.conf
-	echo "net.ipv6.conf.default.disable_ipv6=1 #kali-anonsurf" >> /etc/sysctl.conf
-	sysctl -p > /dev/null  # have sysctl reread /etc/sysctl.conf
+	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/kali-anonsurf.conf       # add lines to sysctl.conf that will kill ipv6 services
+	# add lines to /etc/sysctl.d/kali-anonsurf.conf that will kill ipv6 services
+	echo "net.ipv6.conf.all.disable_ipv6 = 1 #kali-anonsurf" >> /etc/sysctl.d/kali-anonsurf.conf
+	echo "net.ipv6.conf.default.disable_ipv6=1 #kali-anonsurf" >> /etc/sysctl.d/kali-anonsurf.conf
+	sysctl -p /etc/sysctl.d/kali-anonsurf.conf > /dev/null  # have sysctl reread /etc/sysctl.d/kali-anonsurf.conf
+
+
 
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Starting anonymous mode:$RESETCOLOR\n"
 	
@@ -248,8 +250,8 @@ function stop {
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Reenabling IPv6 services:$RESETCOLOR\n"
 
 	# reenable IPv6 services
-	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.conf #delete lines containing #kali-anonsurf in /etc/sysctl.conf
-	sysctl -p # have sysctl reread /etc/sysctl.conf
+	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/kali-anonsurf.conf
+	sysctl --system > /dev/null # have sysctl reread system
 
 	service network-manager force-reload > /dev/null 2>&1
 	service nscd start > /dev/null 2>&1

--- a/kali-anonsurf-deb-src/etc/init.d/anonsurf
+++ b/kali-anonsurf-deb-src/etc/init.d/anonsurf
@@ -136,11 +136,11 @@ function start {
 	
 	# Kill IPv6 services
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Stopping IPv6 services:$RESETCOLOR\n"
-	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/kali-anonsurf.conf
-	# add lines to /etc/sysctl.d/kali-anonsurf.conf that will kill ipv6 services
-	echo "net.ipv6.conf.all.disable_ipv6 = 1 #kali-anonsurf" >> /etc/sysctl.d/kali-anonsurf.conf
-	echo "net.ipv6.conf.default.disable_ipv6=1 #kali-anonsurf" >> /etc/sysctl.d/kali-anonsurf.conf
-	sysctl -p /etc/sysctl.d/kali-anonsurf.conf > /dev/null  # have sysctl reread /etc/sysctl.d/kali-anonsurf.conf
+	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/98-kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/98-kali-anonsurf.conf
+	# add lines to /etc/sysctl.d/98-kali-anonsurf.conf that will kill ipv6 services
+	echo "net.ipv6.conf.all.disable_ipv6 = 1 #kali-anonsurf" >> /etc/sysctl.d/98-kali-anonsurf.conf
+	echo "net.ipv6.conf.default.disable_ipv6=1 #kali-anonsurf" >> /etc/sysctl.d/98-kali-anonsurf.conf
+	sysctl -p /etc/sysctl.d/98-kali-anonsurf.conf > /dev/null  # have sysctl reread /etc/sysctl.d/98-kali-anonsurf.conf
 
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Starting anonymous mode:$RESETCOLOR\n"
 	
@@ -248,7 +248,7 @@ function stop {
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Reenabling IPv6 services:$RESETCOLOR\n"
 
 	# reenable IPv6 services
-	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/kali-anonsurf.conf
+	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/98-kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/98-kali-anonsurf.conf
 	sysctl --system > /dev/null # have sysctl reread system
 
 	service network-manager force-reload > /dev/null 2>&1

--- a/kali-anonsurf-deb-src/etc/init.d/anonsurf
+++ b/kali-anonsurf-deb-src/etc/init.d/anonsurf
@@ -136,7 +136,7 @@ function start {
 	
 	# Kill IPv6 services
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Stopping IPv6 services:$RESETCOLOR\n"
-	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/kali-anonsurf.conf       # add lines to sysctl.conf that will kill ipv6 services
+	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/kali-anonsurf.con
 	# add lines to /etc/sysctl.d/kali-anonsurf.conf that will kill ipv6 services
 	echo "net.ipv6.conf.all.disable_ipv6 = 1 #kali-anonsurf" >> /etc/sysctl.d/kali-anonsurf.conf
 	echo "net.ipv6.conf.default.disable_ipv6=1 #kali-anonsurf" >> /etc/sysctl.d/kali-anonsurf.conf

--- a/kali-anonsurf-deb-src/etc/init.d/anonsurf
+++ b/kali-anonsurf-deb-src/etc/init.d/anonsurf
@@ -108,6 +108,68 @@ function stopi2p {
 	fi
 }
 
+function disable_ipv6() {
+    echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Stopping IPv6 services:$RESETCOLOR\n"
+
+    # Remove current IPv6 settings if it exists
+    if [ -f /etc/sysctl.d/98-kali-anonsurf.conf ]; then
+        rm /etc/sysctl.d/98-kali-anonsurf.conf
+    fi
+
+    # Add comprehensive IPv6 disable configuration
+    cat << EOF >> /etc/sysctl.d/98-kali-anonsurf.conf
+# Disable IPv6 - Added by kali-anonsurf
+net.ipv6.conf.all.disable_ipv6 = 1 #kali-anonsurf
+net.ipv6.conf.default.disable_ipv6 = 1 #kali-anonsurf
+net.ipv6.conf.lo.disable_ipv6 = 1 #kali-anonsurf
+EOF
+
+    # Apply settings
+    if ! sysctl -p /etc/sysctl.d/98-kali-anonsurf.conf > /dev/null; then
+        echo -e "$RED Error applying sysctl settings$RESETCOLOR"
+        return 1
+    fi
+
+    # Verify IPv6 is disabled
+    if [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" != "1" ]; then
+        echo -e "$RED Failed to disable IPv6$RESETCOLOR"
+        return 1
+    fi
+
+    echo -e "$GREEN IPv6 successfully disabled$RESETCOLOR"
+    return 0
+}
+
+function enable_ipv6() {
+    echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Reenabling IPv6 services:$RESETCOLOR\n"
+
+    # Remove the config file if it exists
+    if [ -f /etc/sysctl.d/backup/98-kali-anonsurf ]; then
+        rm -f /etc/sysctl.d/98-kali-anonsurf.conf
+		echo -e "$GREEN Removed anonsurf sysctl config$RESETCOLOR"
+    fi
+
+    # Reload all sysctl settings
+    if ! sysctl --system > /dev/null; then
+        echo -e "$RED Error reloading sysctl settings$RESETCOLOR"
+        return 1
+    fi
+
+    # Verify IPv6 is enabled
+    if [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" != "0" ]; then
+        echo -e "$RED Failed to forcibly reenable IPv6$RESETCOLOR"
+        # return 1
+    fi
+
+    # Restart network services
+    service network-manager force-reload > /dev/null 2>&1
+    service nscd start > /dev/null 2>&1
+    service dnsmasq start > /dev/null 2>&1
+
+    echo -e "$GREEN IPv6 successfully enabled$RESETCOLOR"
+    return 0
+}
+
 
 function ip {
 
@@ -134,13 +196,7 @@ function start {
 		exit 1
 	fi	
 	
-	# Kill IPv6 services
-	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Stopping IPv6 services:$RESETCOLOR\n"
-	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/98-kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/98-kali-anonsurf.conf
-	# add lines to /etc/sysctl.d/98-kali-anonsurf.conf that will kill ipv6 services
-	echo "net.ipv6.conf.all.disable_ipv6 = 1 #kali-anonsurf" >> /etc/sysctl.d/98-kali-anonsurf.conf
-	echo "net.ipv6.conf.default.disable_ipv6=1 #kali-anonsurf" >> /etc/sysctl.d/98-kali-anonsurf.conf
-	sysctl -p /etc/sysctl.d/98-kali-anonsurf.conf > /dev/null  # have sysctl reread /etc/sysctl.d/98-kali-anonsurf.conf
+	disable_ipv6
 
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Starting anonymous mode:$RESETCOLOR\n"
 	
@@ -248,12 +304,7 @@ function stop {
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Reenabling IPv6 services:$RESETCOLOR\n"
 
 	# reenable IPv6 services
-    rm -f /etc/sysctl.d/98-kali-anonsurf.conf #remove /etc/sysctl.d/98-kali-anonsurf.conf
-	sysctl --system > /dev/null # have sysctl reread system
-
-	service network-manager force-reload > /dev/null 2>&1
-	service nscd start > /dev/null 2>&1
-	service dnsmasq start > /dev/null 2>&1
+	enable_ipv6
 	
 	echo -e " $GREEN*$BLUE Anonymous mode stopped$RESETCOLOR\n"
 }

--- a/kali-anonsurf-deb-src/etc/init.d/anonsurf
+++ b/kali-anonsurf-deb-src/etc/init.d/anonsurf
@@ -248,7 +248,7 @@ function stop {
 	echo -e "\n$GREEN[$BLUE i$GREEN ]$BLUE Reenabling IPv6 services:$RESETCOLOR\n"
 
 	# reenable IPv6 services
-	sed -i '/^.*\#kali-anonsurf$/d' /etc/sysctl.d/98-kali-anonsurf.conf #delete lines containing #kali-anonsurf in /etc/sysctl.d/98-kali-anonsurf.conf
+    rm -f /etc/sysctl.d/98-kali-anonsurf.conf #remove /etc/sysctl.d/98-kali-anonsurf.conf
 	sysctl --system > /dev/null # have sysctl reread system
 
 	service network-manager force-reload > /dev/null 2>&1


### PR DESCRIPTION
A minor suggestion. It helped me fix the issue I was facing, when kali-anonsurf reported that /etc/sysctl.conf was not found (minimal kali wsl2).

I moved the ipv6 configs from /etc/sysctl.conf to /etc/sysctl.d/kali-anonsurf.conf .

Up to you ^_^