### PR TITLE
fix(installer): chmod /DEBIAN and fakeroot

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -25,8 +25,17 @@ apt-get update # Update repos
 apt-get install -y secure-delete tor i2p  i2p-router # install dependencies, just in case
 
 # Configure and install the .deb
-chmod 755 -R kali-anonsurf-deb-src/DEBIAN   # Ensure the DEBIAN folder is executable
-fakeroot dpkg-deb -b kali-anonsurf-deb-src/ kali-anonsurf.deb # Build the deb package
+chmod 755 -R kali-anonsurf-deb-src/DEBIAN # Ensure the DEBIAN folder is executable
+
+# Check if fakeroot is installed
+if command -v fakeroot > /dev/null; then
+    echo "fakeroot is available, using it to build the .deb package."
+    fakeroot dpkg-deb -b kali-anonsurf-deb-src/ kali-anonsurf.deb
+else
+    echo "fakeroot is not available, building the .deb package without it."
+    dpkg-deb -b kali-anonsurf-deb-src/ kali-anonsurf.deb
+fi
+
 dpkg -i kali-anonsurf.deb || (apt-get -f install && dpkg -i kali-anonsurf.deb) # this will automatically install the required packages
 
 

--- a/installer.sh
+++ b/installer.sh
@@ -25,7 +25,8 @@ apt-get update # Update repos
 apt-get install -y secure-delete tor i2p  i2p-router # install dependencies, just in case
 
 # Configure and install the .deb
-dpkg-deb -b kali-anonsurf-deb-src/ kali-anonsurf.deb # Build the deb package
+chmod 755 -R kali-anonsurf-deb-src/DEBIAN   # Ensure the DEBIAN folder is executable
+fakeroot dpkg-deb -b kali-anonsurf-deb-src/ kali-anonsurf.deb # Build the deb package
 dpkg -i kali-anonsurf.deb || (apt-get -f install && dpkg -i kali-anonsurf.deb) # this will automatically install the required packages
 
 

--- a/kali-anonsurf-deb-src/DEBIAN/control
+++ b/kali-anonsurf-deb-src/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: kali-anonsurf
-Version: 1.2.6.0
+Version: 1.2.6.1
 Architecture: all
 Maintainer: Und3rf10w
 Installed-Size: 64

--- a/kali-anonsurf-deb-src/DEBIAN/control
+++ b/kali-anonsurf-deb-src/DEBIAN/control
@@ -5,7 +5,6 @@ Maintainer: Und3rf10w
 Installed-Size: 64
 Depends: secure-delete, tor, i2p
 Recommends: gtkdialog, socat, gufw, proxychains, openvpn
-Suggests: vidalia
 Section: net
 Priority: optional
 Description: Parrot stealth and anon scripts, ported to work with Kali Linux

--- a/kali-anonsurf-deb-src/DEBIAN/control
+++ b/kali-anonsurf-deb-src/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: kali-anonsurf
-Version: 1.2.6.1
+Version: 1.2.7.0
 Architecture: all
 Maintainer: Und3rf10w
 Installed-Size: 64


### PR DESCRIPTION
when installing the new script on Debian/lmde I get an error because the DEBIAN-Folder has wrong priviliges. This error was not existing 3 weeks ago. anyway, I found a solution, by adding a chmod line.

Also, the installed files belong to the user, even though they shold be secured. therefore, I use fakeroot for dpkg-deb, then the packages are made correctly.

note: this is my first pull request ever. Please doublecheck and forgive if I messed up.

also I didn't dive into that yml-stuff, maybe the build_package.yml also needs to get a fakeroot?