### PR TITLE
fix(installer): update i2p keyring URL and follow redirects

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -17,7 +17,7 @@ fi
 
 # Compile the i2p ppa
 echo "deb [signed-by=/usr/share/keyrings/i2p-archive-keyring.gpg] https://deb.i2p.net/ $(dpkg --status tzdata | grep Provides | cut -f2 -d'-') main" > /etc/apt/sources.list.d/i2p.list
-curl -o i2p-archive-keyring.gpg https://geti2p.net/_static/i2p-archive-keyring.gpg
+curl -Lo i2p-archive-keyring.gpg https://i2p.net/i2p-archive-keyring.gpg
 chmod 644 i2p-archive-keyring.gpg
 mv i2p-archive-keyring.gpg /usr/share/keyrings
 apt-get update # Update repos

--- a/kali-anonsurf-deb-src/DEBIAN/control
+++ b/kali-anonsurf-deb-src/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: kali-anonsurf
-Version: 1.3.0.0
+Version: 1.4.0.0
 Architecture: all
 Maintainer: Und3rf10w
 Installed-Size: 64


### PR DESCRIPTION
## Summary

The installer downloads the i2p repository signing key to authenticate the apt repository at `deb.i2p.net`. The old URL (`https://geti2p.net/_static/i2p-archive-keyring.gpg`) now returns a **301 redirect** to `https://i2p.net/i2p-archive-keyring.gpg`, but `curl` without `-L` doesn't follow redirects — it saves the HTML redirect page instead of the actual keyring.

This causes `apt` to reject the key file, the i2p repository to be unavailable, and the installation to fail with missing `i2p` and `i2p-router` packages.

## Change

| File | Change |
|------|--------|
| `installer.sh` | Use direct URL `https://i2p.net/i2p-archive-keyring.gpg` + add `-L` to follow any future redirects |

## Verification

- Fingerprint verified: `7840 E761 0F28 B904 7535 49D7 67EC E560 5BCF 1346` (matches official I2P Debian Package Repository key)
- The official [I2P Debian install guide](https://geti2p.net/en/docs/guides/installing-i2p-on-debian-and-ubuntu) recommends `https://i2p.net/i2p-archive-keyring.gpg`
- Tested on Kali Linux Rolling (2026.2) — installation completes successfully

## Test Plan

- [x] `curl -Lo` downloads a valid OpenPGP key (13847 bytes, not 265 bytes of HTML)
- [x] `apt-get update` on the i2p repository succeeds with no signature errors
- [x] `apt-get install i2p i2p-router` installs successfully
